### PR TITLE
Adding `inline` to functions that cause linking errors

### DIFF
--- a/include/a2ddefs.h
+++ b/include/a2ddefs.h
@@ -82,9 +82,9 @@ A2D_FUNCTION double fmt(A2D_complex_t<T> val) {
   return val.real();
 }
 
-A2D_FUNCTION double fmt(double val) { return val; }
+A2D_FUNCTION inline double fmt(double val) { return val; }
 
-double absfunc(A2D_complex_t<double> a) {
+inline double absfunc(A2D_complex_t<double> a) {
   if (a.real() >= 0.0) {
     return a.real();
   } else {
@@ -92,7 +92,7 @@ double absfunc(A2D_complex_t<double> a) {
   }
 }
 
-double absfunc(double a) {
+inline double absfunc(double a) {
   if (a >= 0.0) {
     return a;
   } else {
@@ -100,9 +100,9 @@ double absfunc(double a) {
   }
 }
 
-double RealPart(double a) { return a; }
+inline double RealPart(double a) { return a; }
 
-double RealPart(A2D_complex_t<double> a) { return a.real(); }
+inline double RealPart(A2D_complex_t<double> a) { return a.real(); }
 
 /*
   Remove the const-ness and references for a type

--- a/include/ad/a2dgemm.h
+++ b/include/ad/a2dgemm.h
@@ -389,7 +389,7 @@ bool MatMatMultTestHelper(bool component = false, bool write_output = true) {
   return passed;
 }
 
-bool MatMatMultTestAll(bool component = false, bool write_output = true) {
+inline bool MatMatMultTestAll(bool component = false, bool write_output = true) {
   bool passed = true;
   passed =
       passed && MatMatMultTestHelper<double, 3, 3, 3>(component, write_output);

--- a/include/ad/a2dgreenstrain.h
+++ b/include/ad/a2dgreenstrain.h
@@ -172,7 +172,7 @@ class MatGreenStrainTest : public A2DTest<T, SymMat<T, N>, Mat<T, N, N>> {
   }
 };
 
-bool MatGreenStrainTestAll(bool component = false, bool write_output = true) {
+inline bool MatGreenStrainTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dhadamard.h
+++ b/include/ad/a2dhadamard.h
@@ -181,7 +181,7 @@ class VecHadamardTest : public A2DTest<T, Vec<T, N>, Vec<T, N>, Vec<T, N>> {
   }
 };
 
-bool VecHadamardTestAll(bool component = false, bool write_output = true) {
+inline bool VecHadamardTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2disotropic.h
+++ b/include/ad/a2disotropic.h
@@ -329,7 +329,7 @@ class SymIsotropicTest : public A2DTest<T, SymMat<T, N>, T, T, SymMat<T, N>> {
   }
 };
 
-bool SymIsotropicTestAll(bool component = false, bool write_output = true) {
+inline bool SymIsotropicTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dmatdet.h
+++ b/include/ad/a2dmatdet.h
@@ -263,7 +263,7 @@ class SymMatDetTest : public A2DTest<T, T, SymMat<T, N>> {
   }
 };
 
-bool MatDetTestAll(bool component = false, bool write_output = true) {
+inline bool MatDetTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dmatinv.h
+++ b/include/ad/a2dmatinv.h
@@ -186,7 +186,7 @@ class MatInvTest : public A2DTest<T, Mat<T, N, N>, Mat<T, N, N>> {
   }
 };
 
-bool MatInvTestAll(bool component = false, bool write_output = true) {
+inline bool MatInvTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dmatsum.h
+++ b/include/ad/a2dmatsum.h
@@ -405,7 +405,7 @@ class MatSumScaleTest
   }
 };
 
-bool MatSumTestAll(bool component = false, bool write_output = true) {
+inline bool MatSumTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dmattrace.h
+++ b/include/ad/a2dmattrace.h
@@ -292,7 +292,7 @@ class SymTraceTest : public A2DTest<T, T, SymMat<T, N>> {
   }
 };
 
-bool MatTraceTestAll(bool component = false, bool write_output = true) {
+inline bool MatTraceTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dmatvecmult.h
+++ b/include/ad/a2dmatvecmult.h
@@ -292,7 +292,7 @@ bool MatVecMultTestHelper(bool component = false, bool write_output = true) {
   return passed;
 }
 
-bool MatVecMultTestAll(bool component = false, bool write_output = true) {
+inline bool MatVecMultTestAll(bool component = false, bool write_output = true) {
   bool passed = true;
   passed =
       passed && MatVecMultTestHelper<double, 3, 3>(component, write_output);

--- a/include/ad/a2dquaternion.h
+++ b/include/ad/a2dquaternion.h
@@ -292,7 +292,7 @@ class QuaternionMatrixTest : public A2DTest<T, Mat<T, 3, 3>, Vec<T, 4>> {
   }
 };
 
-bool QuaternionMatrixTestAll(bool component = false, bool write_output = true) {
+inline bool QuaternionMatrixTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   QuaternionMatrixTest<Tc> test1;
@@ -442,7 +442,7 @@ bool TestQuaternions(QuaternionAngularVelocityTest<T> test,
   return passed;
 }
 
-bool QuaternionAngularVelocityTestAll(bool component = false,
+inline bool QuaternionAngularVelocityTestAll(bool component = false,
                                       bool write_output = true) {
   using Tc = std::complex<double>;
 

--- a/include/ad/a2dscalarops.h
+++ b/include/ad/a2dscalarops.h
@@ -150,7 +150,7 @@ class ScalarTest : public A2DTest<T, T, T, T> {
   }
 };
 
-bool ScalarTestAll(bool component, bool write_output) {
+inline bool ScalarTestAll(bool component, bool write_output) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dsymeigs.h
+++ b/include/ad/a2dsymeigs.h
@@ -524,7 +524,7 @@ class SymEigsTest : public A2DTest<T, Vec<T, N>, SymMat<T, N>> {
   }
 };
 
-bool SymEigsTestAll(bool component = false, bool write_output = true) {
+inline bool SymEigsTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dsymmatmulttrace.h
+++ b/include/ad/a2dsymmatmulttrace.h
@@ -154,7 +154,7 @@ class SymMatMultTraceTest : public A2DTest<T, T, SymMat<T, N>, SymMat<T, N>> {
   }
 };
 
-bool SymMatMultTraceTestAll(bool component = false, bool write_output = true) {
+inline bool SymMatMultTraceTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dsymrk.h
+++ b/include/ad/a2dsymrk.h
@@ -329,7 +329,7 @@ bool SymMatRKTestHelper(bool component = false, bool write_output = true) {
   return passed;
 }
 
-bool SymMatRKTestAll(bool component = false, bool write_output = true) {
+inline bool SymMatRKTestAll(bool component = false, bool write_output = true) {
   bool passed = true;
   passed = passed && SymMatRKTestHelper<double, 3, 3>(component, write_output);
   passed = passed && SymMatRKTestHelper<double, 2, 4>(component, write_output);

--- a/include/ad/a2dsymsum.h
+++ b/include/ad/a2dsymsum.h
@@ -321,7 +321,7 @@ class SymMatSumScaleTest : public A2DTest<T, SymMat<T, N>, T, Mat<T, N, N>> {
   }
 };
 
-bool SymMatSumTestAll(bool component = false, bool write_output = true) {
+inline bool SymMatSumTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dunary.h
+++ b/include/ad/a2dunary.h
@@ -28,10 +28,10 @@ namespace A2D {
     }                                                                       \
     A2D_FUNCTION void forward() {                                           \
       a.forward();                                                          \
-      bval = (DERIVBODY)*a.bvalue();                                        \
+      bval = (DERIVBODY) * a.bvalue();                                      \
     }                                                                       \
     A2D_FUNCTION void reverse() {                                           \
-      a.bvalue() += (DERIVBODY)*bval;                                       \
+      a.bvalue() += (DERIVBODY) * bval;                                     \
       a.reverse();                                                          \
     }                                                                       \
     A2D_FUNCTION void bzero() {                                             \
@@ -86,15 +86,15 @@ A2D_1ST_UNARY_BASIC(UnaryNeg, operator-, -a.value(), -T(1.0))
       val = (FUNCBODY);                                                        \
     }                                                                          \
     A2D_FUNCTION void reverse() {                                              \
-      a.bvalue() += (DERIVBODY)*bval;                                          \
+      a.bvalue() += (DERIVBODY) * bval;                                        \
       a.reverse();                                                             \
     }                                                                          \
     A2D_FUNCTION void hforward() {                                             \
       a.hforward();                                                            \
-      pval = (DERIVBODY)*a.pvalue();                                           \
+      pval = (DERIVBODY) * a.pvalue();                                         \
     }                                                                          \
     A2D_FUNCTION void hreverse() {                                             \
-      a.hvalue() += (DERIVBODY)*hval;                                          \
+      a.hvalue() += (DERIVBODY) * hval;                                        \
       a.hreverse();                                                            \
     }                                                                          \
     A2D_FUNCTION void bzero() {                                                \
@@ -158,10 +158,10 @@ A2D_2ND_UNARY_BASIC(UnaryNeg2, operator-, -a.value(), -T(1.0))
     }                                                                   \
     A2D_FUNCTION void forward() {                                       \
       a.forward();                                                      \
-      bval = (DERIVBODY)*a.bvalue();                                    \
+      bval = (DERIVBODY) * a.bvalue();                                  \
     }                                                                   \
     A2D_FUNCTION void reverse() {                                       \
-      a.bvalue() += (DERIVBODY)*bval;                                   \
+      a.bvalue() += (DERIVBODY) * bval;                                 \
       a.reverse();                                                      \
     }                                                                   \
     A2D_FUNCTION void bzero() {                                         \
@@ -225,15 +225,15 @@ A2D_1ST_UNARY(ASinExpr, asin, std::asin(a.value()),
       tmp = (TEMPBODY);                                                        \
     }                                                                          \
     A2D_FUNCTION void reverse() {                                              \
-      a.bvalue() += (DERIVBODY)*bval;                                          \
+      a.bvalue() += (DERIVBODY) * bval;                                        \
       a.reverse();                                                             \
     }                                                                          \
     A2D_FUNCTION void hforward() {                                             \
       a.hforward();                                                            \
-      pval = (DERIVBODY)*a.pvalue();                                           \
+      pval = (DERIVBODY) * a.pvalue();                                         \
     }                                                                          \
     A2D_FUNCTION void hreverse() {                                             \
-      a.hvalue() += (DERIVBODY)*hval + (DERIV2BODY)*bval * a.pvalue();         \
+      a.hvalue() += (DERIVBODY) * hval + (DERIV2BODY) * bval * a.pvalue();     \
       a.hreverse();                                                            \
     }                                                                          \
     A2D_FUNCTION void bzero() {                                                \

--- a/include/ad/a2dveccross.h
+++ b/include/ad/a2dveccross.h
@@ -421,7 +421,7 @@ class VecCross2DTest : public A2DTest<T, Vec<T, 2>, Vec<T, 2>, T> {
   }
 };
 
-bool VecCrossTestAll(bool component = false, bool write_output = true) {
+inline bool VecCrossTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dvecnorm.h
+++ b/include/ad/a2dvecnorm.h
@@ -462,7 +462,7 @@ class VecNormTest : public A2DTest<T, T, Vec<T, N>> {
   }
 };
 
-bool VecNormTestAll(bool component = false, bool write_output = true) {
+inline bool VecNormTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;
@@ -518,7 +518,7 @@ class VecScaleTest : public A2DTest<T, Vec<T, N>, T, Vec<T, N>> {
   }
 };
 
-bool VecScaleTestAll(bool component = false, bool write_output = true) {
+inline bool VecScaleTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;
@@ -571,7 +571,7 @@ class VecNormalizeTest : public A2DTest<T, Vec<T, N>, Vec<T, N>> {
   }
 };
 
-bool VecNormalizeTestAll(bool component = false, bool write_output = true) {
+inline bool VecNormalizeTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;
@@ -627,7 +627,7 @@ class VecDotTest : public A2DTest<T, T, Vec<T, N>, Vec<T, N>> {
   }
 };
 
-bool VecDotTestAll(bool component = false, bool write_output = true) {
+inline bool VecDotTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dvecouter.h
+++ b/include/ad/a2dvecouter.h
@@ -215,7 +215,7 @@ class VecOuterTest : public A2DTest<T, Mat<T, N, M>, Vec<T, N>, Vec<T, M>> {
   }
 };
 
-bool VecOuterTestAll(bool component = false, bool write_output = true) {
+inline bool VecOuterTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;

--- a/include/ad/a2dvecsum.h
+++ b/include/ad/a2dvecsum.h
@@ -415,7 +415,7 @@ class VecSumScaleTest
   }
 };
 
-bool VecSumTestAll(bool component = false, bool write_output = true) {
+inline bool VecSumTestAll(bool component = false, bool write_output = true) {
   using Tc = std::complex<double>;
 
   bool passed = true;


### PR DESCRIPTION
I ran into a bunch of errors like the one below while to compile an executable against an object file that used A2D. Adding the `inline` keyword to all these functions fixes the issue, but @aaronyicongfu suggested that for the `TestAll` functions it would be better to move them out of a2d/include and into the tests directory. I'm not sure how to do this though.

```
/usr/bin/ld: /tmp/cc3uYngw.o: in function `A2D::fmt(double)':
RunTACS.cpp:(.text+0x1650): multiple definition of `A2D::fmt(double)'; ../element/ResidualKernelPrototype.o:ResidualKernelPrototype.cpp:(.text+0x1650): first defined here
```