### PR TITLE
Modifications to ADScalar Constructors

### DIFF
--- a/include/ad/a2dmatinv.h
+++ b/include/ad/a2dmatinv.h
@@ -22,11 +22,11 @@ namespace A2D {
 */
 
 template <typename T, int N>
-A2D_FUNCTION void MatInv(const Mat<T, N, N>& A, Mat<T, N, N>& Ainv) {
+A2D_FUNCTION void MatInv(const Mat<T, N, N> &A, Mat<T, N, N> &Ainv) {
   MatInvCore<T, N>(get_data(A), get_data(Ainv));
 }
 template <typename T, int N>
-A2D_FUNCTION void MatInv(const SymMat<T, N>& S, SymMat<T, N>& Sinv) {
+A2D_FUNCTION void MatInv(const SymMat<T, N> &S, SymMat<T, N> &Sinv) {
   SymMatInvCore<T, N>(get_data(S), get_data(Sinv));
 }
 
@@ -56,7 +56,7 @@ class MatInvExpr {
   static constexpr MatOp NORMAL = MatOp::NORMAL;
   static constexpr MatOp TRANSPOSE = MatOp::TRANSPOSE;
 
-  A2D_FUNCTION MatInvExpr(Atype& A, Btype& Ainv) : A(A), Ainv(Ainv) {}
+  A2D_FUNCTION MatInvExpr(Atype &A, Btype &Ainv) : A(A), Ainv(Ainv) {}
 
   A2D_FUNCTION void eval() { MatInvCore<T, N>(get_data(A), get_data(Ainv)); }
 
@@ -67,8 +67,8 @@ class MatInvExpr {
     static_assert(
         !(order == ADorder::FIRST and forder == ADorder::SECOND),
         "Can't perform second order forward with first order objects");
-    constexpr ADseed seed = conditional_value<ADseed, forder == ADorder::FIRST,
-                                              ADseed::b, ADseed::p>::value;
+    constexpr ADseed seed = conditional_value < ADseed,
+                     forder == ADorder::FIRST, ADseed::b, ADseed::p > ::value;
 
     T temp[N * N];
     MatMatMultCore<T, N, N, N, N, N, N, NORMAL, NORMAL>(
@@ -120,17 +120,17 @@ class MatInvExpr {
         T(-1.0), temp, get_data(Ainv), GetSeed<ADseed::h>::get_data(A));
   }
 
-  Atype& A;
-  Btype& Ainv;
+  Atype &A;
+  Btype &Ainv;
 };
 
 template <class Atype, class Btype>
-A2D_FUNCTION auto MatInv(ADObj<Atype>& A, ADObj<Btype>& Ainv) {
+A2D_FUNCTION auto MatInv(ADObj<Atype> &A, ADObj<Btype> &Ainv) {
   return MatInvExpr<ADObj<Atype>, ADObj<Btype>>(A, Ainv);
 }
 
 template <class Atype, class Btype>
-A2D_FUNCTION auto MatInv(A2DObj<Atype>& A, A2DObj<Btype>& Ainv) {
+A2D_FUNCTION auto MatInv(A2DObj<Atype> &A, A2DObj<Btype> &Ainv) {
   return MatInvExpr<A2DObj<Atype>, A2DObj<Btype>>(A, Ainv);
 }
 
@@ -150,7 +150,7 @@ class MatInvTest : public A2DTest<T, Mat<T, N, N>, Mat<T, N, N>> {
   }
 
   // Evaluate the matrix-matrix product
-  Output eval(const Input& x) {
+  Output eval(const Input &x) {
     Mat<T, N, N> A;
     Mat<T, N, N> B;
     x.get_values(A);
@@ -159,7 +159,7 @@ class MatInvTest : public A2DTest<T, Mat<T, N, N>, Mat<T, N, N>> {
   }
 
   // Compute the derivative
-  void deriv(const Output& seed, const Input& x, Input& g) {
+  void deriv(const Output &seed, const Input &x, Input &g) {
     ADObj<Mat<T, N, N>> A;
     ADObj<Mat<T, N, N>> B;
 
@@ -171,8 +171,8 @@ class MatInvTest : public A2DTest<T, Mat<T, N, N>, Mat<T, N, N>> {
   }
 
   // Compute the second-derivative
-  void hprod(const Output& seed, const Output& hval, const Input& x,
-             const Input& p, Input& h) {
+  void hprod(const Output &seed, const Output &hval, const Input &x,
+             const Input &p, Input &h) {
     A2DObj<Mat<T, N, N>> A;
     A2DObj<Mat<T, N, N>> B;
 

--- a/include/ad/a2dmatinv.h
+++ b/include/ad/a2dmatinv.h
@@ -67,8 +67,8 @@ class MatInvExpr {
     static_assert(
         !(order == ADorder::FIRST and forder == ADorder::SECOND),
         "Can't perform second order forward with first order objects");
-    constexpr ADseed seed = conditional_value < ADseed,
-                     forder == ADorder::FIRST, ADseed::b, ADseed::p > ::value;
+    constexpr ADseed seed = conditional_value<ADseed, forder == ADorder::FIRST,
+                                              ADseed::b, ADseed::p>::value;
 
     T temp[N * N];
     MatMatMultCore<T, N, N, N, N, N, N, NORMAL, NORMAL>(

--- a/include/ad/a2dobj.h
+++ b/include/ad/a2dobj.h
@@ -784,39 +784,33 @@ struct __get_object_numeric_type<ADScalar<A2D_complex_t<double>, N>> {
   using type = ADScalar<A2D_complex_t<double>, N>;
 };
 
-template <typename T, int N,
-          std::enable_if_t<is_numeric_type<T>::value, bool> = true>
+template <typename T, int N>
 ADScalar<T, N>& get_data(ADScalar<T, N>& value) {
   return value;
 }
 
-template <typename T, int N,
-          std::enable_if_t<is_numeric_type<T>::value, bool> = true>
+template <typename T, int N>
 const ADScalar<T, N>& get_data(const ADScalar<T, N>& value) {
   return value;
 }
 
-template <typename T, int N,
-          std::enable_if_t<is_numeric_type<T>::value, bool> = true>
+template <typename T, int N>
 A2D_FUNCTION ADScalar<T, N>& get_data(ADObj<ADScalar<T, N>>& value) {
   return value.value();
 }
 
-template <typename T, int N,
-          std::enable_if_t<is_numeric_type<T>::value, bool> = true>
+template <typename T, int N>
 A2D_FUNCTION const ADScalar<T, N>& get_data(
     const ADObj<ADScalar<T, N>>& value) {
   return value.value();
 }
 
-template <typename T, int N,
-          std::enable_if_t<is_numeric_type<T>::value, bool> = true>
+template <typename T, int N>
 A2D_FUNCTION ADScalar<T, N>& get_data(A2DObj<ADScalar<T, N>>& value) {
   return value.value();
 }
 
-template <typename T, int N,
-          std::enable_if_t<is_numeric_type<T>::value, bool> = true>
+template <typename T, int N>
 A2D_FUNCTION const ADScalar<T, N>& get_data(
     const A2DObj<ADScalar<T, N>>& value) {
   return value.value();

--- a/include/adscalar.h
+++ b/include/adscalar.h
@@ -24,8 +24,9 @@ public:
   template <typename R, typename = std::enable_if_t<is_scalar_type<R>::value>>
   A2D_FUNCTION ADScalar(const R value) : value(value), deriv{0.0} {}
 
-  // Value and derivative constructor (sets both, and works regardless of the type T)
-  A2D_FUNCTION ADScalar(const T& value, const T d[]) : value(value) {
+  // Value and derivative constructor (sets both, and works regardless of the
+  // type T)
+  A2D_FUNCTION ADScalar(const T &value, const T d[]) : value(value) {
     for (int i = 0; i < N; i++) {
       deriv[i] = d[i];
     }

--- a/include/adscalar.h
+++ b/include/adscalar.h
@@ -9,13 +9,16 @@
 namespace A2D {
 
 // Detections for scalar types
-template <class> struct is_adscalar : std::false_type {};
+template <class>
+struct is_adscalar : std::false_type {};
 template <class U, int M>
 struct is_adscalar<ADScalar<U, M>> : std::true_type {};
-template <class X> inline constexpr bool is_adscalar_v = is_adscalar<X>::value;
+template <class X>
+inline constexpr bool is_adscalar_v = is_adscalar<X>::value;
 
-template <class T, int N> class ADScalar {
-public:
+template <class T, int N>
+class ADScalar {
+ public:
   using type = T;
 
   A2D_FUNCTION ADScalar() {}
@@ -51,13 +54,12 @@ public:
                                               is_adscalar_v<T>),
                                          int> = 0>
   explicit ADScalar(const ADScalar<R, N> &r) {
-
     if constexpr (is_adscalar_v<T>) {
       // Lifting: occurs if T is an ADScalar<...> type
       // copy the entire ADScalar r into 'value' for the current ADScalar
-      value = r; // invokes inner ADScalar's conversion/copy
+      value = r;  // invokes inner ADScalar's conversion/copy
       for (int i = 0; i < N; ++i) {
-        deriv[i] = T(0.0); // outer derivatives zeroed
+        deriv[i] = T(0.0);  // outer derivatives zeroed
       }
     } else {
       // Componentwise: T is a plain scalar-like type (e.g. double)
@@ -183,7 +185,7 @@ public:
       negderivs[i] = -deriv[i];
     }
     return ADScalar<T, N>(-value,
-                          negderivs); // Return by value, not by reference
+                          negderivs);  // Return by value, not by reference
   }
 
   //  private:
@@ -397,6 +399,6 @@ A2D_FUNCTION inline ADScalar<X, M> cos(const ADScalar<X, M> &r) {
 //   using type = ADScalar<A2D_complex_t<double>,N>;
 // };
 
-} // namespace A2D
+}  // namespace A2D
 
-#endif // A2D_ADSCALAR_H
+#endif  // A2D_ADSCALAR_H

--- a/include/adscalar.h
+++ b/include/adscalar.h
@@ -24,13 +24,16 @@ public:
   template <typename R, typename = std::enable_if_t<is_scalar_type<R>::value>>
   A2D_FUNCTION ADScalar(const R value) : value(value), deriv{0.0} {}
 
-  // Value and derivative constructor (sets both)
-  template <typename R, typename = std::enable_if_t<is_scalar_type<R>::value>>
-  A2D_FUNCTION ADScalar(const R value, const T d[]) : value(value) {
+  // Value and derivative constructor (sets both, and works regardless of the type T)
+  A2D_FUNCTION ADScalar(const T& value, const T d[]) : value(value) {
     for (int i = 0; i < N; i++) {
       deriv[i] = d[i];
     }
   }
+
+  // Scalar-only version for ADScalar constructor for a common occasion
+  template <typename R, typename = std::enable_if_t<is_scalar_type<R>::value>>
+  ADScalar(const R val, const T d[]) : ADScalar(T(val), d) {}
 
   // Copy constructor (sets value and derivatives from another ADScalar)
   A2D_FUNCTION ADScalar(const ADScalar<T, N> &r) : value(r.value) {

--- a/tests/ad/CMakeLists.txt
+++ b/tests/ad/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(test_ad_expressions test_ad_expressions.cpp)
 add_executable(test_a2dmat test_a2dmat.cpp)
 add_executable(test_a2dmatinv test_a2dmatinv.cpp)
 add_executable(test_a2dmatdet test_a2dmatdet.cpp)
+add_executable(test_adscalar test_adscalar.cpp)
 
 target_compile_options(test_ad_expressions PRIVATE -fsanitize=address)
 target_link_options(test_ad_expressions PRIVATE -fsanitize=address)
@@ -15,6 +16,8 @@ target_include_directories(test_a2dmat PRIVATE
 target_include_directories(test_a2dmatinv PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/tests)
 target_include_directories(test_a2dmatdet PRIVATE
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/tests)
+target_include_directories(test_adscalar PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/tests)
 
 # For tests implmented using gtest, link them to gtest
@@ -29,5 +32,6 @@ gtest_discover_tests(test_a2dmatdet)
 
 # Add non-gtest tests manually so that ctest could recognize it's a test
 add_test(NAME test_ad_expressions COMMAND test_ad_expressions)
+add_test(NAME test_adscalar COMMAND test_adscalar)
 
 add_subdirectory(core)

--- a/tests/ad/test_adscalar.cpp
+++ b/tests/ad/test_adscalar.cpp
@@ -1,0 +1,141 @@
+#include <functional>
+#include <iostream>
+#include <vector>
+
+#include "a2dcore.h"
+
+using namespace A2D;
+
+template <typename T> class ADScalarTest : public A2D::Test::A2DTest<T, T, T> {
+public:
+  using Input = VarTuple<T, T>;
+  using Output = VarTuple<T, T>;
+
+  std::string name() override { return "ADScalarTest"; }
+
+  // Evaluate f(x) = x^2 using ADScalar
+  Output eval(const Input &x) override {
+    T val;
+    x.get_values(val);
+    ADScalar<T, 1> ad_x(val);
+    ADScalar<T, 1> ad_y = ad_x * ad_x;
+    return MakeVarTuple<T>(ad_y.value);
+  }
+
+  // Compute the derivative: df/dx = 2x using ADScalar
+  void deriv(const Output &seed, const Input &x, Input &g) override {
+    T val;
+    x.get_values(val);
+    T dy;
+    seed.get_values(dy);
+    ADScalar<T, 1> ad_x(val);
+    ad_x.deriv[0] = dy;
+    ADScalar<T, 1> ad_y = ad_x * ad_x;
+    g.set_values(ad_y.deriv[0]);
+  }
+
+  // Compute the second derivative: d^2f/dx^2 = 2 using ADScalar
+  void hprod(const Output &seed, const Output &hval, const Input &x,
+             const Input &p, Input &h) override {
+    T val, pval, dy, ddy;
+    x.get_values(val);
+    p.get_values(pval);
+    seed.get_values(dy);
+    hval.get_values(ddy);
+    ADScalar<T, 1> ad_x(val);
+    ad_x.deriv[0] = pval;
+    ADScalar<T, 1> ad_y = ad_x * ad_x;
+    // Second derivative: d^2f/dx^2 * p = 2 * pval
+    h.set_values(2.0 * pval * dy + 2.0 * ddy * val);
+  }
+};
+
+template <typename T>
+class ADScalarNestedTest : public A2D::Test::A2DTest<T, T, T> {
+public:
+  using Input = VarTuple<T, T>;
+  using Output = VarTuple<T, T>;
+
+  std::string name() override { return "ADScalarNestedTest"; }
+
+  // Evaluate f(x) = x^2 using nested ADScalar
+  Output eval(const Input &x) override {
+    T val;
+    x.get_values(val);
+    ADScalar<T, 1> ad_x(val);
+    ADScalar<ADScalar<T, 1>, 1> nested_x(ad_x);
+    ADScalar<ADScalar<T, 1>, 1> nested_y = nested_x * nested_x;
+    return MakeVarTuple<T>(nested_y.value.value); // Unwrap both layers
+  }
+
+  // Compute the derivative: df/dx = 2x using nested ADScalar
+  void deriv(const Output &seed, const Input &x, Input &g) override {
+
+    T val;
+    x.get_values(val);
+    T dy;
+    seed.get_values(dy);
+
+    ADScalar<T, 1> ad_x(val);
+    ad_x.deriv[0] = dy;
+
+    ADScalar<ADScalar<T, 1>, 1> nested_x(ad_x);
+
+    ADScalar<ADScalar<T, 1>, 1> nested_y = nested_x * nested_x;
+
+    g.set_values(
+        nested_y.value.deriv[0]); // Unwrap derivative from inner ADScalar
+  }
+
+  // Compute the second derivative: d^2f/dx^2 = 2 using nested ADScalar
+  void hprod(const Output &seed, const Output &hval, const Input &x,
+             const Input &p, Input &h) override {
+    T val, pval, dy, ddy;
+    x.get_values(val);
+    p.get_values(pval);
+    seed.get_values(dy);
+    hval.get_values(ddy);
+    ADScalar<T, 1> ad_x(val);
+    ad_x.deriv[0] = pval;
+    ADScalar<ADScalar<T, 1>, 1> nested_x(ad_x);
+    nested_x.deriv[0] = ADScalar<T, 1>(0.0);
+    ADScalar<ADScalar<T, 1>, 1> nested_y = nested_x * nested_x;
+    // Second derivative: d^2f/dx^2 * p = 2 * pval
+    h.set_values(2.0 * pval * dy + 2.0 * ddy * val);
+  }
+};
+bool ADScalarTestAll(bool component, bool write_output) {
+  using Tc = A2D_complex_t<double>;
+
+  bool passed = true;
+  ADScalarTest<Tc> test;
+  test.set_step_size(1e-30);
+
+  ADScalarNestedTest<Tc> nested_test;
+  nested_test.set_step_size(1e-30);
+
+  passed = passed && Run(test, component, write_output);
+  passed = passed && Run(nested_test, component, write_output);
+
+  return passed;
+}
+
+int main(int argc, char *argv[]) {
+  bool component = false;    // Default to a projection test
+  bool write_output = false; // Don't write output;
+
+  // Check for the write_output flag
+  for (int i = 0; i < argc; i++) {
+    std::string str(argv[i]);
+    if (str.compare("--write_output") == 0) {
+      write_output = true;
+    }
+    if (str.compare("--component") == 0) {
+      component = true;
+    }
+  }
+
+  bool passed = ADScalarTestAll(component, write_output);
+
+  return passed ? 0 : 1;
+}

--- a/tests/ad/test_adscalar.cpp
+++ b/tests/ad/test_adscalar.cpp
@@ -6,8 +6,9 @@
 
 using namespace A2D;
 
-template <typename T> class ADScalarTest : public A2D::Test::A2DTest<T, T, T> {
-public:
+template <typename T>
+class ADScalarTest : public A2D::Test::A2DTest<T, T, T> {
+ public:
   using Input = VarTuple<T, T>;
   using Output = VarTuple<T, T>;
 
@@ -52,7 +53,7 @@ public:
 
 template <typename T>
 class ADScalarNestedTest : public A2D::Test::A2DTest<T, T, T> {
-public:
+ public:
   using Input = VarTuple<T, T>;
   using Output = VarTuple<T, T>;
 
@@ -65,12 +66,11 @@ public:
     ADScalar<T, 1> ad_x(val);
     ADScalar<ADScalar<T, 1>, 1> nested_x(ad_x);
     ADScalar<ADScalar<T, 1>, 1> nested_y = nested_x * nested_x;
-    return MakeVarTuple<T>(nested_y.value.value); // Unwrap both layers
+    return MakeVarTuple<T>(nested_y.value.value);  // Unwrap both layers
   }
 
   // Compute the derivative: df/dx = 2x using nested ADScalar
   void deriv(const Output &seed, const Input &x, Input &g) override {
-
     T val;
     x.get_values(val);
     T dy;
@@ -84,7 +84,7 @@ public:
     ADScalar<ADScalar<T, 1>, 1> nested_y = nested_x * nested_x;
 
     g.set_values(
-        nested_y.value.deriv[0]); // Unwrap derivative from inner ADScalar
+        nested_y.value.deriv[0]);  // Unwrap derivative from inner ADScalar
   }
 
   // Compute the second derivative: d^2f/dx^2 = 2 using nested ADScalar
@@ -121,8 +121,8 @@ bool ADScalarTestAll(bool component, bool write_output) {
 }
 
 int main(int argc, char *argv[]) {
-  bool component = false;    // Default to a projection test
-  bool write_output = false; // Don't write output;
+  bool component = false;     // Default to a projection test
+  bool write_output = false;  // Don't write output;
 
   // Check for the write_output flag
   for (int i = 0; i < argc; i++) {


### PR DESCRIPTION
Modified the definitions for ADScalar constructors to support nested ADScalar objects. Implemented a test that verifies the functionality for both an ADScalar<T, 1> and a single-nested (i.e. ADScalar<ADScalar<T, 1>, 1>) ADScalar object.